### PR TITLE
Energy capacity method for CC:Tweaked

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/EnergyBlockEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/EnergyBlockEntity.java
@@ -187,7 +187,7 @@ public abstract class EnergyBlockEntity extends BlockEntity
 		return ENERGY_STORAGE.canReceive();
 	}
 	
-	public long getCapacity()
+	public long getEnergyCapacity()
 	{
 		return ENERGY_STORAGE.getTrueMaxEnergyStored();
 	}

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/InterfacePeripheral.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/InterfacePeripheral.java
@@ -91,14 +91,20 @@ public class InterfacePeripheral implements IPeripheral, IDynamicPeripheral
 	//============================================================================================
 	//*****************************************CC: Tweaked****************************************
 	//============================================================================================
-	
-	@LuaFunction
+
+	@LuaFunction(mainThread = true)
 	public final long getEnergy() throws LuaException
 	{
 		return interfaceEntity.getEnergyStored();
 	}
-	
-	@LuaFunction
+
+	@LuaFunction(mainThread = true)
+	public final long getEnergyCapacity() throws LuaException
+	{
+		return interfaceEntity.getEnergyCapacity();
+	}
+
+	@LuaFunction(mainThread = true)
 	public final long getEnergyTarget() throws LuaException
 	{
 		return interfaceEntity.getEnergyTarget();

--- a/src/main/java/net/povstalec/sgjourney/common/menu/InterfaceMenu.java
+++ b/src/main/java/net/povstalec/sgjourney/common/menu/InterfaceMenu.java
@@ -37,7 +37,7 @@ public class InterfaceMenu extends AbstractContainerMenu
     
     public long getMaxEnergy()
     {
-    	return this.interfaceEntity.getCapacity();
+    	return this.interfaceEntity.getEnergyCapacity();
     }
 	
 	@Override

--- a/src/main/java/net/povstalec/sgjourney/common/menu/NaquadahGeneratorMenu.java
+++ b/src/main/java/net/povstalec/sgjourney/common/menu/NaquadahGeneratorMenu.java
@@ -55,7 +55,7 @@ public class NaquadahGeneratorMenu extends AbstractContainerMenu
     
     public long getMaxEnergy()
     {
-    	return this.blockEntity.getCapacity();
+    	return this.blockEntity.getEnergyCapacity();
     }
 	
 	@Override


### PR DESCRIPTION
- Added `getEnergyCapacity` method for CC:Tweaked
- Renamed `getCapacity` to `getEnergyCapacity` in `EnergyBlockEntity` for clarity