### PR TITLE
Fixed issue with CC functions that take a table as an input.

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/methods/StargateFilterMethods.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/methods/StargateFilterMethods.java
@@ -65,6 +65,7 @@ public class StargateFilterMethods
 		@Override
 		public MethodResult use(IComputerAccess computer, ILuaContext context, AbstractInterfaceEntity interfaceEntity, AbstractStargateEntity stargate, IArguments arguments) throws LuaException
 		{
+			arguments.escapes();
 			MethodResult result = context.executeMainThreadTask(() ->
 			{
 				Map<Double, Double> addressMap = (Map<Double, Double>) arguments.getTable(0);
@@ -105,6 +106,7 @@ public class StargateFilterMethods
 		@Override
 		public MethodResult use(IComputerAccess computer, ILuaContext context, AbstractInterfaceEntity interfaceEntity, AbstractStargateEntity stargate, IArguments arguments) throws LuaException
 		{
+			arguments.escapes();
 			MethodResult result = context.executeMainThreadTask(() ->
 			{
 				Map<Double, Double> addressMap = (Map<Double, Double>) arguments.getTable(0);
@@ -169,6 +171,7 @@ public class StargateFilterMethods
 		@Override
 		public MethodResult use(IComputerAccess computer, ILuaContext context, AbstractInterfaceEntity interfaceEntity, AbstractStargateEntity stargate, IArguments arguments) throws LuaException
 		{
+			arguments.escapes();
 			MethodResult result = context.executeMainThreadTask(() ->
 			{
 				Map<Double, Double> addressMap = (Map<Double, Double>) arguments.getTable(0);
@@ -209,6 +212,7 @@ public class StargateFilterMethods
 		@Override
 		public MethodResult use(IComputerAccess computer, ILuaContext context, AbstractInterfaceEntity interfaceEntity, AbstractStargateEntity stargate, IArguments arguments) throws LuaException
 		{
+			arguments.escapes();
 			MethodResult result = context.executeMainThreadTask(() ->
 			{
 				Map<Double, Double> addressMap = (Map<Double, Double>) arguments.getTable(0);

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/methods/StargateMethods.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/methods/StargateMethods.java
@@ -150,6 +150,7 @@ public class StargateMethods
 		@Override
 		public MethodResult use(IComputerAccess computer, ILuaContext context, AbstractInterfaceEntity interfaceEntity, AbstractStargateEntity stargate, IArguments arguments) throws LuaException
 		{
+			arguments.escapes();
 			MethodResult result = context.executeMainThreadTask(() ->
 			{
 				Map<Double, Double> chevronConfiguration = (Map<Double, Double>) arguments.getTable(0);


### PR DESCRIPTION
This fork fixes the following computercraft functions which throw the `java.lang.IllegalStateException: Function arguments have escaped their original scope.` error in the 1.20.1 version of the mod:
`addToWhitelist`
`addToBlacklist`
`removeFromWhitelist`
`removeFromBlacklist`
`setChevronConfiguration`