### PR TITLE
fix(jei): prevent modifying itemstack from ingredient

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/jei/AdvancedCrystallizerRecipeCategory.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/jei/AdvancedCrystallizerRecipeCategory.java
@@ -72,9 +72,9 @@ public class AdvancedCrystallizerRecipeCategory implements IRecipeCategory<Advan
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, AdvancedCrystallizerRecipe recipe, IFocusGroup focuses)
 	{
-		ItemStack stack1 = recipe.getIngredients().get(0).getItems()[0];
-		ItemStack stack2 = recipe.getIngredients().get(1).getItems()[0];
-		ItemStack stack3 = recipe.getIngredients().get(2).getItems()[0];
+		ItemStack stack1 = recipe.getIngredients().get(0).getItems()[0].copy();
+		ItemStack stack2 = recipe.getIngredients().get(1).getItems()[0].copy();
+		ItemStack stack3 = recipe.getIngredients().get(2).getItems()[0].copy();
 		
 		stack1.setCount(recipe.getAmountInSlot(0));
 		stack2.setCount(recipe.getAmountInSlot(1));

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/jei/CrystallizerRecipeCategory.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/jei/CrystallizerRecipeCategory.java
@@ -73,9 +73,9 @@ public class CrystallizerRecipeCategory implements IRecipeCategory<CrystallizerR
 	@Override
 	public void setRecipe(IRecipeLayoutBuilder builder, CrystallizerRecipe recipe, IFocusGroup focuses)
 	{
-		ItemStack stack1 = recipe.getIngredients().get(0).getItems()[0];
-		ItemStack stack2 = recipe.getIngredients().get(1).getItems()[0];
-		ItemStack stack3 = recipe.getIngredients().get(2).getItems()[0];
+		ItemStack stack1 = recipe.getIngredients().get(0).getItems()[0].copy();
+		ItemStack stack2 = recipe.getIngredients().get(1).getItems()[0].copy();
+		ItemStack stack3 = recipe.getIngredients().get(2).getItems()[0].copy();
 		
 		stack1.setCount(recipe.getAmountInSlot(0));
 		stack2.setCount(recipe.getAmountInSlot(1));


### PR DESCRIPTION
Hello 👋  , I'm making this PR to this mod to add compatibility to a feature (Ingredient Deduplication) on my mod (AllTheLeaks) that relies heavily on modders to not modify the inner stack of those ingredients.

I would greatly appreciate it if you could accept this PR.

Thanks.