### PR TITLE
[Fix] Cables and energy tech incorrectly using and reporting directions for energy capabilities

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/tech/CableBlockEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/tech/CableBlockEntity.java
@@ -143,7 +143,7 @@ public abstract class CableBlockEntity extends BlockEntity
 			BlockEntity blockEntity =  level.getBlockEntity(outputPos);
 			if(blockEntity != null && !(blockEntity instanceof CableBlockEntity))
 			{
-				IEnergyStorage energy = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction).resolve().orElse(null);
+				IEnergyStorage energy = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite()).resolve().orElse(null);
 				if(energy != null)
 				{
 					if(energy.canReceive())
@@ -179,9 +179,9 @@ public abstract class CableBlockEntity extends BlockEntity
 			BlockEntity blockEntity =  level.getBlockEntity(outputPos);
 			if(blockEntity != null)
 			{
-				IEnergyStorage energy = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction).resolve().orElse(null);
+				IEnergyStorage energy = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite()).resolve().orElse(null);
 				
-				if(energy.canReceive())
+				if(energy != null && energy.canReceive())
 				{
 					if(energy instanceof SGJourneyEnergy sgjourneyEnergy && sgjourneyEnergy.getTrueEnergyStored() < sgjourneyEnergy.getTrueMaxEnergyStored())
 						outputs++;
@@ -199,7 +199,7 @@ public abstract class CableBlockEntity extends BlockEntity
 		if(blockEntity == null)
 			return 0;
 		
-		IEnergyStorage energy = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction).resolve().orElse(null);
+		IEnergyStorage energy = blockEntity.getCapability(ForgeCapabilities.ENERGY, direction.getOpposite()).resolve().orElse(null);
 		if(energy == null || !energy.canReceive())
 			return 0;
 		

--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/tech/NaquadahGeneratorEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/tech/NaquadahGeneratorEntity.java
@@ -205,7 +205,7 @@ public abstract class NaquadahGeneratorEntity extends EnergyBlockEntity
 		Direction bottom = getBottomDirection();
 		
 		if(direction != null && bottom != null)
-			return side == bottom.getOpposite() || side == direction.getClockWise() || side == direction.getCounterClockWise();
+			return side == bottom || side == direction.getClockWise() || side == direction.getCounterClockWise();
 		
 		return false;
 	}

--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/tech/ZPMHubEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/tech/ZPMHubEntity.java
@@ -157,7 +157,7 @@ public class ZPMHubEntity extends EnergyBlockEntity implements ProtectedBlockEnt
 	@Override
 	public boolean isCorrectEnergySide(Direction side)
 	{
-		return side == Direction.UP;
+		return side == Direction.DOWN;
 	}
 	
 	protected boolean receivesEnergy()

--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/tech_interface/AbstractInterfaceEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/tech_interface/AbstractInterfaceEntity.java
@@ -189,7 +189,7 @@ public abstract class AbstractInterfaceEntity extends EnergyBlockEntity
 	@Override
 	public boolean isCorrectEnergySide(Direction side)
 	{
-		if(side == getDirection().getOpposite())
+		if(side == getDirection())
 			return false;
 		return true;
 	}

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/tech/CableBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/tech/CableBlock.java
@@ -168,6 +168,7 @@ public abstract class CableBlock extends Block implements SimpleWaterloggedBlock
 	{
 		BlockPos otherPos = pos.relative(direction);
 		BlockState state = getter.getBlockState(otherPos);
+		Direction otherDirection = direction.getOpposite();
 		
 		if(state.isAir())
 			return ConnectorType.NONE;
@@ -177,7 +178,7 @@ public abstract class CableBlock extends Block implements SimpleWaterloggedBlock
 		
 		BlockEntity blockEntity = getter.getBlockEntity(otherPos);
 		if(blockEntity != null)
-			return blockEntity.getCapability(ForgeCapabilities.ENERGY, direction).isPresent() ? ConnectorType.BLOCK : ConnectorType.NONE;
+			return blockEntity.getCapability(ForgeCapabilities.ENERGY, otherDirection).isPresent() ? ConnectorType.BLOCK : ConnectorType.NONE;
 		
 		if(state.getBlock() instanceof LightningRodBlock && state.getValue(LightningRodBlock.FACING) == direction)
 			return ConnectorType.BLOCK;


### PR DESCRIPTION
Cables were checking the opposite direction for energy capability, and other techs were updated for it, which is wrong and even breaks the specs of the getCapability method "the side to check from".
In the image from the left you can see connection between sided energy acceptor from ae2 with ad astra cables, ae2 with SGJ cables, ad astra with naq. generator and then mekanism cables with naq. generator and ZPM hub.
The connections are "correct" only between SGJ and AdAstra since both mods use the wrong implementation.

<img width="1007" height="542" alt="{4D02FEDB-4CEE-41DF-A057-4E9716707912}" src="https://github.com/user-attachments/assets/871d9228-6d74-479e-a495-db474ad6d726" />

<img width="567" height="452" alt="image" src="https://github.com/user-attachments/assets/ee7acf36-33ca-4664-8aea-66a776a9da43" />

AdAstra fixed their implementation later (I think 1.20.1+)
Yes, this will break connections of AdAstra cables with SGJ tech on old versions (<1.20.1), but will fix connections with others.

With this PR applied (only connections with ad astra are broken):
<img width="1086" height="621" alt="{E64BE9FD-C710-4395-8A70-6F685303B285}" src="https://github.com/user-attachments/assets/ee6be205-92f9-4620-8f60-c757f17be33d" />


