### PR TITLE
Added publishing with JavaDocs and sources jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'idea'
     id 'net.minecraftforge.gradle' version '[6.0,6.2)'
     id 'org.parchmentmc.librarian.forgegradle' version '1.+'
+	id 'maven-publish'
 }
 
 version = mod_version
@@ -153,4 +154,18 @@ tasks.named('jar', Jar).configure {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+	publications {
+		mavenJava(MavenPublication) {
+			artifactId = mod_id
+			from components.java
+		}
+	}
 }

--- a/src/main/java/net/povstalec/sgjourney/common/tech/AncientTech.java
+++ b/src/main/java/net/povstalec/sgjourney/common/tech/AncientTech.java
@@ -20,7 +20,7 @@ public interface AncientTech
 	/**
 	 * 
 	 * @param requirementsDisabled Whether or not the requirements for having Ancient Gene to use this have been disabled
-	 * @param player
+	 * @param user
 	 * @return
 	 */
 	default boolean canUseAncientTech(boolean requirementsDisabled, Entity user)


### PR DESCRIPTION
Added publishing plugin.
To test publishing to your local maven you can use `./gradlew publishToMavenLocal` command
To pull your mod from local maven you can use `modImplementation("net.povstalec.sgjourney:sgjourney:0.6.42")` in some other mod
Change in `AncientTech.java` is needed because parameter name is different from JavaDoc parameter name