### PR TITLE
Replaced big complicated incorrect algorithms with simple stdlib calls and fixed one-directional equals for Address

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/sgjourney/Address.java
+++ b/src/main/java/net/povstalec/sgjourney/common/sgjourney/Address.java
@@ -219,25 +219,13 @@ public abstract class Address implements Cloneable
 			return true;
 		else if(object instanceof Address address)
 		{
-			for(int i = 0; i < this.getLength(); i++)
-			{
-				if(this.symbolAt(i) != address.symbolAt(i))
-					return false;
-			}
-			
-			return true;
+			return Arrays.equals(addressArray, address.addressArray);
 		}
 		else if(object instanceof AddressFilterInfo.HiddenAddress hiddenAddress)
 			return equals(hiddenAddress.address());
 		else if(object instanceof int[] array)
 		{
-			for(int i = 0; i < array.length; i++)
-			{
-				if(array[i] != this.symbolAt(i))
-					return false;
-			}
-			
-			return true;
+			return Arrays.equals(addressArray, array);
 		}
 		
 		return false;
@@ -246,7 +234,7 @@ public abstract class Address implements Cloneable
 	@Override
 	public int hashCode()
 	{
-		return Objects.hash(symbolAt(0), symbolAt(1), symbolAt(2), symbolAt(3), symbolAt(4), symbolAt(5), symbolAt(6), symbolAt(7), symbolAt(8));
+		return Arrays.hashCode(addressArray);
 	}
 	
 	// Static functions


### PR DESCRIPTION
You've been using only one array length, which makes `equals` work only in one direction (from A to B, but not from B to A) if one address is shorter than the other.
I've fixed it. And also replaced functions with simpler stdlib calls that you might like
P.S.: This PR wasn't tested