### PR TITLE
[Fix] Allow cover blocks removal on NBT update

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/StargateJourney.java
+++ b/src/main/java/net/povstalec/sgjourney/StargateJourney.java
@@ -1,7 +1,10 @@
 package net.povstalec.sgjourney;
 
 import java.util.Calendar;
+import java.util.function.BiFunction;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraftforge.client.event.ModelEvent;
 import net.povstalec.sgjourney.client.models.block.CartoucheModelLoader;
 import net.povstalec.sgjourney.client.models.block.SymbolBlockModelLoader;
@@ -124,9 +127,17 @@ public class StargateJourney
 		
 		ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, StargateJourneyConfig.CLIENT_CONFIG, "sgjourney-client.toml");
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, StargateJourneyConfig.COMMON_CONFIG, "sgjourney-common.toml");
-		
-		ModLoadingContext.get().registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class, 
-				() -> new ConfigScreenHandler.ConfigScreenFactory((mc, screen) -> new ConfigScreen(screen)));
+
+		ModLoadingContext.get().registerExtensionPoint(ConfigScreenHandler.ConfigScreenFactory.class,
+				() -> new ConfigScreenHandler.ConfigScreenFactory(new BiFunction<Minecraft, Screen, Screen>()
+				{
+					// Not using lambda to prevent class loading issues on dedicated server
+					@Override
+					public Screen apply(Minecraft mc, Screen screen)
+					{
+						return new ConfigScreen(screen);
+					}
+				}));
         
 		MinecraftForge.EVENT_BUS.register(this);
 		MinecraftForge.EVENT_BUS.addListener(MiscInit::registerCommands);

--- a/src/main/java/net/povstalec/sgjourney/common/sgjourney/StargateBlockCover.java
+++ b/src/main/java/net/povstalec/sgjourney/common/sgjourney/StargateBlockCover.java
@@ -185,6 +185,8 @@ public class StargateBlockCover implements INBTSerializable<CompoundTag>
 				
 				if(result.isPresent())
 					blockStates.put(part, result.get());
+			} else {
+				removeBlockAt(part);
 			}
 		}
 	}


### PR DESCRIPTION
- Removes cover blocks that are not present in NBT on update of existing object, e.g. with data command.
- Reverts change from Naquadah Pillars (29893191bceac60a6be31f931dea5acc1d03d222) commit that replaced bi function implementation with lambda.
Using lambda triggers client class loading and crashes dedicated servers.

Fixing the cover blocks deserialization presents a workaround for #221, allowing the removal of cover blocks with the data command.

