### PR TITLE
[Fix] Reworks stargate item drops to use vanilla style getDrops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'net.minecraftforge.gradle' version '5.1.+'
+    id 'org.parchmentmc.librarian.forgegradle' version '1.+'
 }
 
 version = "${mod_version}"
@@ -27,7 +28,7 @@ minecraft {
     //
     // Use non-default mappings at your own risk. They may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'official', version: '1.19.3'
+    mappings channel: 'parchment', version: '2023.06.25-1.19.3'
 
     accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg') // Currently, this location cannot be changed from the default.
 
@@ -41,6 +42,9 @@ minecraft {
     
         client {
             workingDirectory project.file('run')
+
+            // allow hotswap with JBR
+            jvmArg "-XX:+AllowEnhancedClassRedefinition"
 
             // Recommended logging data for a userdev environment
             // The markers can be added/remove as needed separated by commas.
@@ -65,7 +69,7 @@ minecraft {
         }
 
         server {
-            workingDirectory project.file('run')
+            workingDirectory project.file('run_server')
 
             property 'forge.logging.markers', 'REGISTRIES'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,6 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven { url = 'https://maven.minecraftforge.net/' }
+        maven { url = 'https://maven.parchmentmc.org' }
     }
 }

--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/stargate/AbstractStargateEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/stargate/AbstractStargateEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.network.Connection;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
@@ -28,6 +29,8 @@ import net.povstalec.sgjourney.common.sgjourney.stargate.BlockEntityStargate;
 import net.povstalec.sgjourney.common.sgjourney.stargate.SGJourneyStargate;
 import net.povstalec.sgjourney.common.sgjourney.stargate.Stargate;
 import net.povstalec.sgjourney.common.sgjourney.stargate.StargateType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.ChatFormatting;

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBaseBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBaseBlock.java
@@ -23,6 +23,8 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
@@ -53,6 +55,7 @@ public abstract class AbstractStargateBaseBlock extends AbstractStargateBlock im
 {
 	public static final String EMPTY = StargateJourney.EMPTY;
 	public static final String LOCAL_POINT_OF_ORIGIN = AbstractStargateEntity.LOCAL_POINT_OF_ORIGIN;
+	private static final List<StargatePart> DIRECT_NEIGHBORS = List.of(StargatePart.LEFT, StargatePart.RIGHT);
 	
 	public AbstractStargateBaseBlock(Properties properties, double width, double horizontalOffset)
 	{
@@ -173,6 +176,7 @@ public abstract class AbstractStargateBaseBlock extends AbstractStargateBlock im
     public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack)
 	{
 		super.setPlacedBy(level, pos, state, placer, stack);
+		AbstractStargateEntity<?> stargate = getStargate(level, pos, state);
 		
 		for(StargatePart part : getParts())
 		{
@@ -186,8 +190,6 @@ public abstract class AbstractStargateBaseBlock extends AbstractStargateBlock im
 						.setValue(WATERLOGGED,  Boolean.valueOf(level.getFluidState(part.getRingPos(pos, state.getValue(FACING), state.getValue(ORIENTATION))).getType() == Fluids.WATER)), 3);
 			}
 		}
-		
-		AbstractStargateEntity<?> stargate = getStargate(level, pos, state);
 		
 		if(stargate instanceof IrisStargateEntity<?> irisStargate)
 			updateIris(level, pos, state, irisStargate.irisInfo().getShieldingState());
@@ -335,7 +337,29 @@ public abstract class AbstractStargateBaseBlock extends AbstractStargateBlock im
 		
 		return null;
 	}
-	
+
+	/**
+	 * Checks if the change came from left or right and verifies that the neighbor is still a valid stargate ring block.
+	 * If not, the base block removes itself.
+	 */
+	@Override
+	public void neighborChanged(BlockState state, Level level, BlockPos pos, Block oldNeighborBlock, BlockPos neighborPos, boolean movedByPiston)
+	{
+		super.neighborChanged(state, level, pos, oldNeighborBlock, neighborPos, movedByPiston);
+		for (StargatePart part : DIRECT_NEIGHBORS)
+		{
+			if (part.getRingPos(pos, state.getValue(FACING), state.getValue(ORIENTATION)).equals(neighborPos)) {
+				Block newNeighborBlock = level.getBlockState(neighborPos).getBlock();
+				boolean wasRing = oldNeighborBlock instanceof AbstractStargateRingBlock;
+				boolean isNowRing = newNeighborBlock instanceof AbstractStargateRingBlock;
+				if (wasRing && !isNowRing)
+				{
+					level.destroyBlock(pos, false);
+				}
+			}
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Nullable
 	protected static <E extends BlockEntity, A extends BlockEntity> BlockEntityTicker<A> createTickerHelper(BlockEntityType<A> typeA, BlockEntityType<E> typeB, BlockEntityTicker<? super E> ticker)

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBaseBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBaseBlock.java
@@ -205,11 +205,8 @@ public abstract class AbstractStargateBaseBlock extends AbstractStargateBlock im
 				stargate.dhdCache.clearTwoWays();
     			stargate.removeStargateFromNetwork();
     		}
-    		
-			dropStargateItem(level, pos, oldState, null);
-    		destroyStargate(level, pos, getParts(), getShieldingParts(), oldState.getValue(FACING), oldState.getValue(ORIENTATION), oldState.getValue(PART));
-    		
-            super.onRemove(oldState, level, pos, newState, isMoving);
+
+			super.onRemove(oldState, level, pos, newState, isMoving);
         }
     }
 	

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBlock.java
@@ -190,24 +190,25 @@ public abstract class AbstractStargateBlock extends Block implements SimpleWater
 	}
 
 	/**
-	 * Extracts block entity from the stargate base block, removes the base block from the level and returns a single element list
+	 * Extracts block entity from the stargate base block and returns a single element list
 	 * with the item stack of the gate.
-	 * If the gate was already marked as dropped or the base block does not exists, empty list is returned.
 	 *
-	 * @return List with the stargate item stack or empty list if the gate was already dropped or could not be accessed.
+	 * @return List with the stargate item stack or empty list if the method was called before or the gate could not be accessed.
 	 * @implSpec Requires {@link LootContextParams#ORIGIN} to be passed in the context, otherwise returns empty list.
+	 * Expects {@link LootContextParams#BLOCK_ENTITY} to be present for the base block.
+	 * @implNote Can be called only once, marks the gate as dropped and any further calls will return empty list.
 	 */
 	@Override
-	public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+	public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder)
+	{
 		final BlockPos originPos = Optional.ofNullable(builder.getOptionalParameter(LootContextParams.ORIGIN))
 				.map(BlockPos::new)
 				.orElse(null);
 
-		if (originPos == null) {
+		if (originPos == null)
+		{
 			return Collections.emptyList();
 		}
-
-		final BlockPos basePos = getBasePos(state, originPos);
 
 		final ItemStack gateStack =
 				// if the location is present find the respective stargate entity
@@ -216,57 +217,53 @@ public abstract class AbstractStargateBlock extends Block implements SimpleWater
 				// or find it in the level (if a ring block was mined)
 				.or(() -> Optional.ofNullable(getStargate(builder.getLevel(), originPos, state)))
 				.filter(blockEntity -> blockEntity instanceof AbstractStargateEntity<?>)
-				// make the item stack
-				.flatMap(stargateEntity -> makeStargateItem(builder.getLevel(), (AbstractStargateEntity<?>) stargateEntity))
+				// make the item stack and mark the gate as dropped
+				.map(stargateEntity -> makeStargateItem(builder.getLevel(), (AbstractStargateEntity<?>) stargateEntity))
 				.orElse(null);
 
 		// if null, the gate entity does not exist or the gate was already marked as dropped
-		if (gateStack == null) {
+		if (gateStack == null)
+		{
 			return Collections.emptyList();
 		}
 
-		// now remove the base block if it exists
-		if (builder.getLevel().getBlockState(basePos).getBlock() instanceof AbstractStargateBaseBlock baseBlock) {
-			builder.getLevel().removeBlock(basePos, false);
-		}
+		// the base block will be removed by block update
 		return List.of(gateStack);
-	}
-
-	private static BlockPos getBasePos(BlockState stargateBlockState, BlockPos blockPos) {
-		return stargateBlockState.getValue(PART).getBaseBlockPos(blockPos, stargateBlockState.getValue(FACING), stargateBlockState.getValue(ORIENTATION));
 	}
 
 	/**
 	 * Converts the stargate to an {@link ItemStack}.
 	 * The gate can be converted only once and is marked as dropped, until placed again.
-	 * @return the {@link ItemStack} if converted, or empty optional if the gate was already "dropped"
+	 * @return the {@link ItemStack} if converted, or {@code null} if the gate was already "dropped"
 	 */
-	public Optional<ItemStack> makeStargateItem(Level level, AbstractStargateEntity<?> stargate)
+	public ItemStack makeStargateItem(Level level, AbstractStargateEntity<?> stargate)
 	{
-		if(level.isClientSide())
-			return Optional.empty();
-
-		if(stargate != null)
+		if(!level.isClientSide() && stargate != null)
 		{
 			if(!stargate.isItemDropped())
 			{
 				stargate.markItemAsDropped(); // mark as dropped to prevent duplication
 				ItemStack itemstack = new ItemStack(asItem());
 				stargate.saveToItem(itemstack);
-				return Optional.of(itemstack);
+				return itemstack;
 			}
 		}
-		return Optional.empty();
+		return null;
 	}
 
 	/**
-	 * Triggers removal of the whole gate except the base block, that will be removed in {@link #getDrops(BlockState, LootContext.Builder)} in order to preserve the block entity.
+	 * Triggers removal of the whole gate except the base block,
+	 * that will be removed in {@link #getDrops(BlockState, LootContext.Builder)} in order to preserve the block entity.
 	 */
 	@Override
-	public void onRemove(BlockState oldState, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+	public void onRemove(BlockState oldState, Level level, BlockPos pos, BlockState newState, boolean movedByPiston)
+	{
+		Direction direction = oldState.getValue(FACING);
+		Orientation orientation = oldState.getValue(ORIENTATION);
+		BlockPos baseBlockPos = oldState.getValue(PART).getBaseBlockPos(pos, direction, orientation);
+		destroyStargate(level, baseBlockPos, getParts(), getShieldingParts(), direction, orientation, StargatePart.BASE);
+
 		super.onRemove(oldState, level, pos, newState, movedByPiston);
-		BlockPos baseBlockPos = getBasePos(oldState, pos);
-		destroyStargate(level, baseBlockPos, getParts(), getShieldingParts(), oldState.getValue(FACING), oldState.getValue(ORIENTATION), StargatePart.BASE);
 	}
 
 	/**
@@ -292,7 +289,8 @@ public abstract class AbstractStargateBlock extends Block implements SimpleWater
 		
 		for(StargatePart part : parts)
 		{
-			if(excludedPart.equals(part)) {
+			if(excludedPart.equals(part))
+			{
 				continue;
 			}
 			BlockPos ringPos = part.getRingPos(pos, direction, orientation);
@@ -301,8 +299,8 @@ public abstract class AbstractStargateBlock extends Block implements SimpleWater
 			if(ringState.getBlock() instanceof AbstractStargateBlock)
 			{
 				boolean waterlogged = ringState.getBlock() instanceof AbstractStargateRingBlock ? ringState.getValue(AbstractStargateRingBlock.WATERLOGGED) : false;
-
-				level.setBlock(ringPos, waterlogged ? Blocks.WATER.defaultBlockState() : Blocks.AIR.defaultBlockState(), 3);
+				BlockState newState = waterlogged ? Blocks.WATER.defaultBlockState() : Blocks.AIR.defaultBlockState();
+				level.setBlock(ringPos, newState, Block.UPDATE_NEIGHBORS | Block.UPDATE_CLIENTS);
 			}
 		}
 	}

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateBlock.java
@@ -1,13 +1,20 @@
 package net.povstalec.sgjourney.common.blocks.stargate;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.HoneycombItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.gameevent.GameEvent;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 import net.povstalec.sgjourney.common.block_entities.ProtectedBlockEntity;
@@ -56,6 +63,8 @@ import net.povstalec.sgjourney.common.blockstates.Orientation;
 import net.povstalec.sgjourney.common.blockstates.ShieldingPart;
 import net.povstalec.sgjourney.common.blockstates.StargateBlockState;
 import net.povstalec.sgjourney.common.blockstates.StargatePart;
+import net.povstalec.sgjourney.common.init.BlockInit;
+import net.povstalec.sgjourney.common.init.TagInit;
 import net.povstalec.sgjourney.common.items.StargateIrisItem;
 import net.povstalec.sgjourney.common.misc.CoverBlockPlaceContext;
 import net.povstalec.sgjourney.common.misc.VoxelShapeProvider;
@@ -180,40 +189,92 @@ public abstract class AbstractStargateBlock extends Block implements SimpleWater
 		return super.updateShape(oldState, direction, newState, levelAccessor, oldPos, newPos);
 	}
 
+	/**
+	 * Extracts block entity from the stargate base block, removes the base block from the level and returns a single element list
+	 * with the item stack of the gate.
+	 * If the gate was already marked as dropped or the base block does not exists, empty list is returned.
+	 *
+	 * @return List with the stargate item stack or empty list if the gate was already dropped or could not be accessed.
+	 * @implSpec Requires {@link LootContextParams#ORIGIN} to be passed in the context, otherwise returns empty list.
+	 */
 	@Override
-	public void playerWillDestroy(Level level, BlockPos pos, BlockState state, Player player)
-	{
-		dropStargateItem(level, pos, state, player);
-		super.playerWillDestroy(level, pos, state, player);
+	public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
+		final BlockPos originPos = Optional.ofNullable(builder.getOptionalParameter(LootContextParams.ORIGIN))
+				.map(BlockPos::new)
+				.orElse(null);
+
+		if (originPos == null) {
+			return Collections.emptyList();
+		}
+
+		final BlockPos basePos = getBasePos(state, originPos);
+
+		final ItemStack gateStack =
+				// if the location is present find the respective stargate entity
+				// extract the block entity from the context (when the base block was mined)
+				Optional.ofNullable(builder.getOptionalParameter(LootContextParams.BLOCK_ENTITY))
+				// or find it in the level (if a ring block was mined)
+				.or(() -> Optional.ofNullable(getStargate(builder.getLevel(), originPos, state)))
+				.filter(blockEntity -> blockEntity instanceof AbstractStargateEntity<?>)
+				// make the item stack
+				.flatMap(stargateEntity -> makeStargateItem(builder.getLevel(), (AbstractStargateEntity<?>) stargateEntity))
+				.orElse(null);
+
+		// if null, the gate entity does not exist or the gate was already marked as dropped
+		if (gateStack == null) {
+			return Collections.emptyList();
+		}
+
+		// now remove the base block if it exists
+		if (builder.getLevel().getBlockState(basePos).getBlock() instanceof AbstractStargateBaseBlock baseBlock) {
+			builder.getLevel().removeBlock(basePos, false);
+		}
+		return List.of(gateStack);
 	}
-	
-	public void dropStargateItem(Level level, BlockPos pos, BlockState state, @Nullable Player player)
+
+	private static BlockPos getBasePos(BlockState stargateBlockState, BlockPos blockPos) {
+		return stargateBlockState.getValue(PART).getBaseBlockPos(blockPos, stargateBlockState.getValue(FACING), stargateBlockState.getValue(ORIENTATION));
+	}
+
+	/**
+	 * Converts the stargate to an {@link ItemStack}.
+	 * The gate can be converted only once and is marked as dropped, until placed again.
+	 * @return the {@link ItemStack} if converted, or empty optional if the gate was already "dropped"
+	 */
+	public Optional<ItemStack> makeStargateItem(Level level, AbstractStargateEntity<?> stargate)
 	{
 		if(level.isClientSide())
-			return;
-		
-		AbstractStargateEntity<?> stargate = getStargate(level, pos, state);
+			return Optional.empty();
+
 		if(stargate != null)
 		{
-			if(!stargate.isItemDropped() && (player == null || !player.isCreative()))
+			if(!stargate.isItemDropped())
 			{
-				stargate.markItemAsDropped(); // Mark item as dropped because it did drop
-				
+				stargate.markItemAsDropped(); // mark as dropped to prevent duplication
 				ItemStack itemstack = new ItemStack(asItem());
-				
 				stargate.saveToItem(itemstack);
-				
-				ItemEntity itementity = new ItemEntity(level, (double)pos.getX() + 0.5D, (double)pos.getY() + 0.5D, (double)pos.getZ() + 0.5D, itemstack);
-				itementity.setDefaultPickUpDelay();
-				itementity.setUnlimitedLifetime();
-				level.addFreshEntity(itementity);
+				return Optional.of(itemstack);
 			}
-			else
-				stargate.markItemAsDropped(); // Mark item as dropped because it could have dropped, but something stopped it (like player being in Creative)
 		}
+		return Optional.empty();
 	}
-	
-	public void destroyStargate(Level level, BlockPos pos, ArrayList<StargatePart> parts, ArrayList<ShieldingPart> shieldingParts, Direction direction, Orientation orientation, StargatePart stargatePart)
+
+	/**
+	 * Triggers removal of the whole gate except the base block, that will be removed in {@link #getDrops(BlockState, LootContext.Builder)} in order to preserve the block entity.
+	 */
+	@Override
+	public void onRemove(BlockState oldState, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+		super.onRemove(oldState, level, pos, newState, movedByPiston);
+		BlockPos baseBlockPos = getBasePos(oldState, pos);
+		destroyStargate(level, baseBlockPos, getParts(), getShieldingParts(), oldState.getValue(FACING), oldState.getValue(ORIENTATION), StargatePart.BASE);
+	}
+
+	/**
+	 * Destroys all the blocks of the stargate multiblock structure except for the {@code excludedPart}
+	 * @param pos the position of the stargate base block
+	 * @param excludedPart part that should not be destroyed
+	 */
+	private void destroyStargate(Level level, BlockPos pos, ArrayList<StargatePart> parts, ArrayList<ShieldingPart> shieldingParts, Direction direction, Orientation orientation, StargatePart excludedPart)
 	{
 		if(direction == null)
 		{
@@ -231,17 +292,17 @@ public abstract class AbstractStargateBlock extends Block implements SimpleWater
 		
 		for(StargatePart part : parts)
 		{
-			if(!stargatePart.equals(part))
+			if(excludedPart.equals(part)) {
+				continue;
+			}
+			BlockPos ringPos = part.getRingPos(pos, direction, orientation);
+			BlockState ringState = level.getBlockState(ringPos);
+
+			if(ringState.getBlock() instanceof AbstractStargateBlock)
 			{
-				BlockPos ringPos = part.getRingPos(pos, direction, orientation);
-				BlockState ringState = level.getBlockState(ringPos);
-				
-				if(ringState.getBlock() instanceof AbstractStargateBlock)
-				{
-					boolean waterlogged = ringState.getBlock() instanceof AbstractStargateRingBlock ? ringState.getValue(AbstractStargateRingBlock.WATERLOGGED) : false;
-					
-					level.setBlock(ringPos, waterlogged ? Blocks.WATER.defaultBlockState() : Blocks.AIR.defaultBlockState(), 3);
-				}
+				boolean waterlogged = ringState.getBlock() instanceof AbstractStargateRingBlock ? ringState.getValue(AbstractStargateRingBlock.WATERLOGGED) : false;
+
+				level.setBlock(ringPos, waterlogged ? Blocks.WATER.defaultBlockState() : Blocks.AIR.defaultBlockState(), 3);
 			}
 		}
 	}

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateRingBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/AbstractStargateRingBlock.java
@@ -56,11 +56,6 @@ public abstract class AbstractStargateRingBlock extends AbstractStargateBlock
 	{
 		if(oldState.getBlock() != newState.getBlock())
 		{
-			BlockPos baseBlockPos = oldState.getValue(PART).getBaseBlockPos(pos, oldState.getValue(FACING), oldState.getValue(ORIENTATION));
-			
-			dropStargateItem(level, pos, oldState, null);
-			destroyStargate(level, baseBlockPos, getParts(false), getShieldingParts(), oldState.getValue(FACING), oldState.getValue(ORIENTATION), oldState.getValue(PART));
-			
 	        super.onRemove(oldState, level, pos, newState, isMoving);
 		}
     }

--- a/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/RotatingStargateBaseBlock.java
+++ b/src/main/java/net/povstalec/sgjourney/common/blocks/stargate/RotatingStargateBaseBlock.java
@@ -32,5 +32,6 @@ public abstract class RotatingStargateBaseBlock extends AbstractStargateBaseBloc
 			else
 				stargate.updateSignal(StargatePart.BASE, 0);
 		}
+		super.neighborChanged(state, level, pos, block, pos2, bool);
 	}
 }


### PR DESCRIPTION
Fixes #187
Fixes #128

The pull request is in progress.
TODO (tests):

- [x] Stargate drops at the position of broken block
Stargate drops when mined with:
- [x] diamond pickaxe
- [x] Create drill (1.21.1)  
- [ ] Create drill (1.20.1 and other versions?)
- [ ] AE2 Annihilation Plane
- [ ] Modular Router with a Block Breaker Module
- [ ] Industrial Foregoing Block Breaker
- [ ] vein mining enchant
- [ ] FTB ultimate
- [ ] Test with area miners 3x3 mining etc.
- [ ] Test the above with coverblocks present
- [ ] Look into showing the mining percentage ("animation") when breaking a ring block, currently shown only when breaking base block
- [ ] Look into old stargate duplication bugs and check they were not reintroduced