### PR TITLE
Update space location templates to always prefer more specific prefixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.java]
+# Move braces to new line for control statements/blocks (if, for, while, etc.)
+ij_java_block_brace_style = next_line
+
+# Move braces to new line for classes and methods
+ij_java_class_brace_style = next_line
+ij_java_method_brace_style = next_line
+
+# Keep control keywords like 'else', 'catch', 'finally' on a new line as well
+ij_java_else_on_new_line = true
+ij_java_catch_on_new_line = true
+ij_java_finally_on_new_line = true

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,8 @@ repositories {
     // flatDir {
     //     dir 'libs'
     // }
+    mavenCentral()
+    mavenLocal()
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"
@@ -137,11 +139,18 @@ repositories {
         }
     }
     maven {
-    url "https://squiddev.cc/maven/"
-    content {
-      includeGroup("cc.tweaked")
-      includeModule("org.squiddev", "Cobalt")
-      includeModule("fuzs.forgeconfigapiport", "forgeconfigapiport-fabric")
+        url "https://cursemaven.com"
+        content {
+            includeGroup "curse.maven"
+        }
+    }
+    maven {
+        url "https://squiddev.cc/maven/"
+        content {
+            includeGroup("cc.tweaked")
+            includeModule("org.squiddev", "Cobalt")
+            includeModule("fuzs.forgeconfigapiport", "forgeconfigapiport-fabric")
+        }
     }
     maven {
         name = "Progwml6 maven jei"
@@ -152,13 +161,6 @@ repositories {
         name = "ModMaven"
         url = "https://modmaven.dev"
     }
-    maven {
-        url "https://cursemaven.com"
-        content {
-            includeGroup "curse.maven"
-        }
-    }
-  }
 }
 
 dependencies {
@@ -199,6 +201,11 @@ dependencies {
     runtimeOnly fg.deobf("curse.maven:mcjtylib-233105:4501792")
     runtimeOnly fg.deobf("curse.maven:rftools-base-326041:5613271")
     runtimeOnly fg.deobf("curse.maven:rftools-dimensions-240950:4500203")
+
+    // test dependencies
+    testImplementation(platform('org.junit:junit-bom:6.1.2'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 }
 
 // Example for how to get properties into the manifest for reading at runtime.
@@ -237,6 +244,13 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 // IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.

--- a/src/main/java/net/povstalec/sgjourney/common/sgjourney/SpaceLocation.java
+++ b/src/main/java/net/povstalec/sgjourney/common/sgjourney/SpaceLocation.java
@@ -281,58 +281,100 @@ public class SpaceLocation
 	{
 		return DIMENSION_SPACE_LOCATIONS.computeIfAbsent(dimension, dimensionKey -> prepareSpaceLocation(dimensionKey, createNewSpaceLocation(server, dimensionKey)));
 	}
+
+    /**
+     * Searches registered location {@link #TEMPLATES} and returns the space location
+     * with most specific (longest) matching prefix if any.
+     *
+     * @param dimension The dimension to match against the template prefix
+     * @return Space location template with most specific matching prefix or {@code null}
+     */
+    @Nullable
+    static SpaceLocation findSpaceLocationTemplate(ResourceKey<Level> dimension)
+    {
+        final String dimLocation = dimension.location().toString();
+        SpaceLocation bestTemplate = null;
+
+        for (Map.Entry<String, SpaceLocation> templateEntry : TEMPLATES.subMap("", true, dimLocation, true).entrySet()) // <- Submap so we're only searching through possible prefixes
+        {
+            final String prefix = templateEntry.getKey();
+            final SpaceLocation locationTemplate = templateEntry.getValue();
+
+            Objects.requireNonNull(locationTemplate.templateInfo, "TemplateInfo of a registered SpaceLocation template cannot be null!");
+            final boolean isMoreSpecific = bestTemplate == null || bestTemplate.templateInfo.prefix.length() < prefix.length();
+
+            if (dimLocation.startsWith(prefix) && isMoreSpecific)
+            {
+                bestTemplate = templateEntry.getValue(); // Update with template that fits the prefix the best
+            }
+        }
+        return bestTemplate;
+    }
+
+    /**
+     * Generates address region from the given {@code template}.
+     * <p>
+     * The address region is registered in respective galaxies.
+     *
+     * @param templateInfo The {@link TemplateInfo} to use for region generation
+     * @param dimension    dimension for which the address region is being created
+     */
+    private static AddressRegion generateAddressRegion(SpaceLocation.TemplateInfo templateInfo, MinecraftServer server, ResourceKey<Level> dimension)
+    {
+        // Assign Space Location to a Galaxy if possible
+        // The only case in which it doesn't get assigned to at least one Galaxy is when the provided list of galaxies is empty
+        if (templateInfo.galaxies != null)
+        {
+            List<Galaxy> galaxyList = new ArrayList<>();
+            for (ResourceKey<Galaxy> galaxyKey : templateInfo.galaxies)
+            {
+                Galaxy galaxy = Universe.get(server).getGalaxy(galaxyKey);
+                if (galaxy != null)
+                    galaxyList.add(galaxy);
+                else
+                    StargateJourney.LOGGER.error("Could not assign Space Location {} to Galaxy {} because the Galaxy is not registered!", dimension.location(), galaxyKey.location());
+            }
+
+            return Universe.get(server).generateNewAddressRegion(dimension, galaxyList);
+        }
+        else
+        {
+            return Universe.get(server).generateNewAddressRegion(dimension, Universe.get(server).getGalaxiesWithGeneratedRegions());
+        }
+    }
+
+    private static SpaceLocation createFromTemplate(SpaceLocation template, MinecraftServer server, ResourceKey<Level> dimension)
+    {
+        Objects.requireNonNull(template.templateInfo, "TemplateInfo cannot be null for SpaceLocation template!");
+        // Create a new Space Location based on an existing template
+        SpaceLocation spaceLocation = template.copyWithoutTemplateInfo();
+        // Generate a new Address Region for the Space Location
+        if (template.templateInfo.generateAddressRegion && Universe.get(server).generateRandomAddressRegions())
+        {
+            AddressRegion region = generateAddressRegion(template.templateInfo, server, dimension);
+            spaceLocation.setAddressRegion(region);
+        }
+        // Assign Space Location to an existing Address Region
+        else if (spaceLocation.addressRegionKey != null)
+        {
+            AddressRegion addressRegion = Universe.get(server).getAddressRegionFromKey(spaceLocation.addressRegionKey);
+            if (addressRegion != null)
+                spaceLocation.setAddressRegion(addressRegion);
+            else
+                StargateJourney.LOGGER.error("Could not assign Space Location {} to Address Region {} because it is not a registered Address Region", dimension.location(), spaceLocation.addressRegionKey.location());
+        }
+        return spaceLocation;
+    }
 	
 	public static SpaceLocation createNewSpaceLocation(MinecraftServer server, ResourceKey<Level> dimension)
 	{
 		// Try finding a template for this Space Location
-		SpaceLocation template = null;
-		for(Map.Entry<String, SpaceLocation> templateEntry : TEMPLATES.subMap("", dimension.location().toString()).entrySet()) // <- Submap so we're only searching through possible prefixes
-		{
-			if(dimension.location().toString().startsWith(templateEntry.getKey()))
-				template = templateEntry.getValue(); // Update with template that fits the prefix the best
-		}
+        SpaceLocation template = findSpaceLocationTemplate(dimension);
 		
 		SpaceLocation spaceLocation;
-		if(template != null)
-		{
-			// Create a new Space Location based on an existing template
-			spaceLocation = template.copyWithoutTemplateInfo();
-			// Generate a new Address Region for the Space Location
-			if(template.templateInfo.generateAddressRegion && Universe.get(server).generateRandomAddressRegions())
-			{
-				// Assign Space Location to a Galaxy if possible (The only case in which it doesn't get assigned to at least one Galaxy is when the provided list of galaxies is empty)
-				if(template.templateInfo.galaxies != null)
-				{
-					List<Galaxy> galaxyList = new ArrayList<>();
-					for(ResourceKey<Galaxy> galaxyKey : template.templateInfo.galaxies)
-					{
-						Galaxy galaxy = Universe.get(server).getGalaxy(galaxyKey);
-						if(galaxy != null)
-							galaxyList.add(galaxy);
-						else
-							StargateJourney.LOGGER.error("Could not assign Space Location {} to Galaxy {} because it is not a registered Galaxy", dimension.location(), galaxyKey.location());
-					}
-					
-					// Assign Space Location to Address Region
-					AddressRegion addressRegion = Universe.get(server).generateNewAddressRegion(dimension, galaxyList);
-					spaceLocation.setAddressRegion(addressRegion);
-				}
-				else
-				{
-					AddressRegion addressRegion = Universe.get(server).generateNewAddressRegion(dimension, Universe.get(server).getGalaxiesWithGeneratedRegions());
-					spaceLocation.setAddressRegion(addressRegion);
-				}
-			}
-			// Assign Space Location to an existing Address Region
-			else if(spaceLocation.addressRegionKey != null)
-			{
-				AddressRegion addressRegion = Universe.get(server).getAddressRegionFromKey(spaceLocation.addressRegionKey);
-				if(addressRegion != null)
-					spaceLocation.setAddressRegion(addressRegion);
-				else
-					StargateJourney.LOGGER.error("Could not assign Space Location {} to Address Region {} because it is not a registered Address Region", dimension.location(), spaceLocation.addressRegionKey.location());
-			}
-			
+        if (template != null)
+        {
+            spaceLocation = createFromTemplate(template, server, dimension);
 		}
 		else
 		{

--- a/src/main/java/net/povstalec/sgjourney/common/sgjourney/SpaceLocation.java
+++ b/src/main/java/net/povstalec/sgjourney/common/sgjourney/SpaceLocation.java
@@ -55,32 +55,46 @@ public class SpaceLocation
 			AddressRegion.RESOURCE_KEY_CODEC.optionalFieldOf(ADDRESS_REGION).forGetter(spaceLocation -> Optional.ofNullable(spaceLocation.addressRegionKey)),
 			Codec.BOOL.optionalFieldOf(PRELOAD_STARGATE, false).forGetter(spaceLocation -> spaceLocation.preloadStargate)
 	).apply(instance, SpaceLocation::new));
-	
-	private static final TreeMap<String, SpaceLocation> TEMPLATES = new TreeMap<>(); // Templates for how to create a Space Location for a Dimension based on its prefix
-	private static final Map<ResourceKey<Level>, SpaceLocation> DIMENSION_SPACE_LOCATIONS = new HashMap<>(); // Map of Dimensions with Space Locations assigned to them
-	private static final List<SpaceLocation> GENERATED_ADDRESS_DIMENSIONS = new ArrayList<>(); // List of Dimensions that allow their Addresses to be found on Cartouches
-	
-	public static double currentGravity = 0; // For controlling gravity on the Client side
-	
+
+	/// Templates for how to create a Space Location for a Dimension based on its prefix
+	private static final TreeMap<String, SpaceLocation> TEMPLATES = new TreeMap<>();
+	/// Map of Dimensions with Space Locations assigned to them
+	private static final Map<ResourceKey<Level>, SpaceLocation> DIMENSION_SPACE_LOCATIONS = new HashMap<>();
+	/// List of Dimensions that allow their Addresses to be found on Cartouches
+	private static final List<SpaceLocation> GENERATED_ADDRESS_DIMENSIONS = new ArrayList<>();
+
+	/// For controlling gravity on the Client side
+	public static double currentGravity = 0;
+
+	/// If not null, this Space Location can be used as a template for Space Locations (for example, ones added at runtime)
 	@Nullable
-	private final TemplateInfo templateInfo; // If not null, this Space Location can be used as a template for Space Locations (for example, ones added at runtime)
-	private final boolean inStargateNetwork; // If false, any Stargate located in this location will not be able to establish any sort of connection
-	private final double parentGravity; // Gravity of the parent body this location might be orbiting - 0.07 for Cavum Tenebrae
+	private final TemplateInfo templateInfo;
+	/// If false, any Stargate located in this location will not be able to establish any sort of connection
+	private final boolean inStargateNetwork;
+	/// Gravity of the parent body this location might be orbiting - 0.07 for Cavum Tenebrae
+	private final double parentGravity;
 	//private boolean allowFactionPresence; // If true, factions will be able to appear in this Dimension
-	private final boolean generateInAddressTables; // If true, dimension address will appear in Address Tables with generated addresses
-	private final boolean unityCrystalsGrow; // If true, Unity Crystals can grow in this location
-	
+	/// If true, dimension address will appear in Address Tables with generated addresses
+	private final boolean generateInAddressTables;
+	/// If true, Unity Crystals can grow in this location
+	private final boolean unityCrystalsGrow;
+
+	/// Point of Origin any Stargates generated in this Space Location will use
 	@Nullable
-	private final ResourceKey<PointOfOrigin> pointOfOrigin; // Point of Origin any Stargates generated in this Space Location will use
+	private final ResourceKey<PointOfOrigin> pointOfOrigin;
+	/// Symbols any Stargates generated in this Space Location will use
 	@Nullable
-	private final ResourceKey<Symbols> symbols; // Symbols any Stargates generated in this Space Location will use
-	
-	private ResourceKey<Level> dimension; // Dimension this Space Location represents
+	private final ResourceKey<Symbols> symbols;
+
+	/// Dimension this Space Location represents
+	private ResourceKey<Level> dimension;
+	/// Address Region this Space Location is a part of
 	@Nullable
-	private ResourceKey<AddressRegion> addressRegionKey; // Address Region this Space Location is a part of
+	private ResourceKey<AddressRegion> addressRegionKey;
 	@Nullable
 	private AddressRegion addressRegion = null;
-	private final boolean preloadStargate; // If true and the Stargate Network does not locate any Stargates in this location, it will attempt to locate and load them from Structures during Stellar Update
+	/// If true and the Stargate Network does not locate any Stargates in this location, it will attempt to locate and load them from Structures during Stellar Update
+	private final boolean preloadStargate;
 	
 	public SpaceLocation(Optional<TemplateInfo> templateInfo, boolean inStargateNetwork, double parentGravity, /*boolean allowFactionPresence, */boolean generateInAddressTables, boolean unityCrystalsGrow,
 						 Optional<ResourceKey<PointOfOrigin>> pointOfOrigin, Optional<ResourceKey<Symbols>> symbols, Optional<ResourceKey<AddressRegion>> addressRegionKey, boolean preloadStargate)

--- a/src/test/java/net/povstalec/sgjourney/common/sgjourney/SpaceLocationTest.java
+++ b/src/test/java/net/povstalec/sgjourney/common/sgjourney/SpaceLocationTest.java
@@ -1,0 +1,65 @@
+package net.povstalec.sgjourney.common.sgjourney;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.Level;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SpaceLocationTest
+{
+    private static final String MOST_SPECIFIC_PREFIX = "minecraft:overworld";
+
+    private static void generateSpaceLocationTemplates(boolean reversed)
+    {
+        SpaceLocation.clear();
+        List<ResourceKey<Galaxy>> galaxies = List.of();
+        Comparator<SpaceLocation.TemplateInfo> comparator = Comparator.comparing(SpaceLocation.TemplateInfo::prefix);
+        if (reversed)
+        {
+            comparator = comparator.reversed();
+        }
+        Stream.of(
+                        new SpaceLocation.TemplateInfo("sgjourney:abydos", false, galaxies),
+                        new SpaceLocation.TemplateInfo("minecraft:ov", false, galaxies),
+                        new SpaceLocation.TemplateInfo("", false, galaxies),
+                        new SpaceLocation.TemplateInfo("minecraft:", false, galaxies),
+                        new SpaceLocation.TemplateInfo(MOST_SPECIFIC_PREFIX, false, galaxies),
+                        new SpaceLocation.TemplateInfo("minecraft:over", false, galaxies),
+                        new SpaceLocation.TemplateInfo("minecraft:the_end", false, galaxies)
+                )
+                .sorted(comparator)
+                .map(info -> new SpaceLocation(info, false, 0f, false, false, null, null, null, false))
+                .forEach(SpaceLocation::registerTemplate);
+    }
+
+    @BeforeAll
+    static void setupMinecraft()
+    {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void findSpaceLocationTemplateReturnsMostSpecificTemplate(boolean reversed)
+    {
+        generateSpaceLocationTemplates(reversed);
+
+        final ResourceKey<Level> dimension = Level.OVERWORLD;
+        final SpaceLocation template = SpaceLocation.findSpaceLocationTemplate(dimension);
+
+        assertNotNull(template);
+        assertNotNull(template.getTemplateInfo());
+        assertEquals(MOST_SPECIFIC_PREFIX, template.getTemplateInfo().prefix());
+    }
+}


### PR DESCRIPTION
This PR updates the resolution of SpaceLocation templates to always prefer more specific prefixes:  
Given two templates with prefixes `rftools` and `rftoolsdim:` and a dimension matching both those prefixes,
then `rftoolsdim:` will take priority.

Side changes:
1. Added editor config to instruct Intellij IDEA to keep the desired bracket placement
2. Added Junit6 library for tests and a single test ensuring the most specific prefix takes priority
3. Moved field comments in SpaceLocation to Javadoc comments
