### PR TITLE
[Fix] Interface not providing and invalidating peripheral capability correctly

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/block_entities/tech_interface/AbstractInterfaceEntity.java
+++ b/src/main/java/net/povstalec/sgjourney/common/block_entities/tech_interface/AbstractInterfaceEntity.java
@@ -128,7 +128,14 @@ public abstract class AbstractInterfaceEntity extends EnergySlotBlockEntity
 			
 		return super.getCapability(cap, side);
 	}
-	
+
+	@Override
+	public void invalidateCaps()
+	{
+		super.invalidateCaps();
+		this.peripheralWrapper.getPeripheral().invalidate();
+	}
+
 	public boolean updateInterface(Level level, BlockPos pos, Block block, BlockState state)
 	{
 		requiresUpdate = true;

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/InterfacePeripheral.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/InterfacePeripheral.java
@@ -20,12 +20,17 @@ import net.povstalec.sgjourney.common.compatibility.computer_functions.Interface
 
 public class InterfacePeripheral implements IDynamicPeripheral
 {
-	protected AbstractInterfaceEntity interfaceEntity;
-	protected HashMap<String, InterfaceMethod<BlockEntity>> methods = new HashMap<>();
+	protected final AbstractInterfaceEntity interfaceEntity;
+	/**
+	 * The entity for which the peripheral was initialized
+	 */
+	protected final BlockEntity targetEntity;
+	protected final HashMap<String, InterfaceMethod<BlockEntity>> methods = new HashMap<>();
 	
-	public InterfacePeripheral(AbstractInterfaceEntity interfaceEntity)
+	public InterfacePeripheral(AbstractInterfaceEntity interfaceEntity, BlockEntity targetEntity)
 	{
 		this.interfaceEntity = interfaceEntity;
+		this.targetEntity = targetEntity;
 		
 		this.registerMethod(new InterfaceMethods.SetEnergyTarget());
 		this.registerMethod(new InterfaceMethods.AddressToString());

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/InterfacePeripheralWrapper.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/InterfacePeripheralWrapper.java
@@ -5,67 +5,67 @@ import java.util.List;
 
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraftforge.common.util.LazyOptional;
 import net.povstalec.sgjourney.common.block_entities.tech.EnergyBlockEntity;
 import net.povstalec.sgjourney.common.block_entities.stargate.AbstractStargateEntity;
 import net.povstalec.sgjourney.common.block_entities.tech_interface.AbstractInterfaceEntity;
 import net.povstalec.sgjourney.common.block_entities.transporter.AbstractTransporterEntity;
 
+import javax.annotation.Nonnull;
+
 public class InterfacePeripheralWrapper
 {
 	private final AbstractInterfaceEntity interfaceEntity;
-	private InterfacePeripheral interfacePeripheral;
-	private LazyOptional<IPeripheral> peripheral;
+	@Nonnull
+	private LazyOptional<InterfacePeripheral> peripheral;
     protected final List<IComputerAccess> computerList = new LinkedList<>();
 	
 	public InterfacePeripheralWrapper(AbstractInterfaceEntity interfaceEntity)
 	{
 		this.interfaceEntity = interfaceEntity;
+		this.peripheral = createPeripheralLazy();
 	}
-	
-	public static InterfacePeripheral createPeripheral(AbstractInterfaceEntity interfaceEntity, EnergyBlockEntity energyBlockEntity)
+
+	private LazyOptional<InterfacePeripheral> createPeripheralLazy() {
+		return LazyOptional.of(() -> createPeripheral(this.interfaceEntity, this.interfaceEntity.findEnergyBlockEntity()));
+	}
+
+	private static InterfacePeripheral createPeripheral(AbstractInterfaceEntity interfaceEntity, EnergyBlockEntity energyBlockEntity)
 	{
 		if(energyBlockEntity instanceof AbstractStargateEntity<?> stargate)
 			return new StargatePeripheral(interfaceEntity, stargate);
 		else if(energyBlockEntity instanceof AbstractTransporterEntity<?> transporter)
 			return new TransporterPeripheral(interfaceEntity, transporter);
 
-		return new InterfacePeripheral(interfaceEntity);
+		return new InterfacePeripheral(interfaceEntity, energyBlockEntity);
 	}
 	
 	public boolean resetInterface()
 	{
-		if(interfacePeripheral != null)
-			interfacePeripheral.markInvalid();
-		
-		InterfacePeripheral newPeripheral = createPeripheral(interfaceEntity, interfaceEntity.findEnergyBlockEntity());
-		if(interfacePeripheral != null && interfacePeripheral.equals(newPeripheral))
-			return false; // Peripheral is same as before, no changes needed.
-		
-		// Peripheral has changed, invalidate the capability and trigger a block update.
-		interfacePeripheral = newPeripheral;
-		if(peripheral != null)
-		{
+		final InterfacePeripheral currentPeripheral = peripheral.resolve().orElse(null);
+		final BlockEntity oldEntity = currentPeripheral == null ? null : currentPeripheral.targetEntity;
+		final BlockEntity newEntity = interfaceEntity.findEnergyBlockEntity();
+
+		// if the peripheral was initialized for a different BE than the interface is currently targeting
+		if (oldEntity != newEntity) {
+			// invalidate the previous peripheral
 			peripheral.invalidate();
-			peripheral = LazyOptional.of(() -> newPeripheral);
+			// create new peripheral initialized, yes Forge (or CC:T) really wants new LazyOptional instance
+			peripheral = createPeripheralLazy();
+			return true;
 		}
-		return true;
+
+		return false;
 	}
 	
 	public void queueEvent(String eventName, Object... objects)
 	{
-		if(interfacePeripheral != null)
-			interfacePeripheral.queueEvent(eventName, objects);
+		peripheral.ifPresent(p -> p.queueEvent(eventName, objects));
 	}
 	
 	public LazyOptional<IPeripheral> getPeripheral()
 	{
-		if(peripheral == null)
-		{
-			interfacePeripheral = createPeripheral(interfaceEntity, interfaceEntity.findEnergyBlockEntity());
-			peripheral = LazyOptional.of(() -> interfacePeripheral);
-		}
-		
-		return peripheral;
+		return peripheral.cast();
 	}
 }

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/StargatePeripheral.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/StargatePeripheral.java
@@ -22,7 +22,7 @@ public class StargatePeripheral extends InterfacePeripheral
 	
 	public StargatePeripheral(AbstractInterfaceEntity interfaceEntity, AbstractStargateEntity<?> stargate)
 	{
-		super(interfaceEntity);
+		super(interfaceEntity, stargate);
 		this.stargate = stargate;
 		
 		stargate.registerInterfaceMethods(new SGJourneyPeripheralWrapper<>(this, interfaceEntity.getInterfaceType()));

--- a/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/TransporterPeripheral.java
+++ b/src/main/java/net/povstalec/sgjourney/common/compatibility/cctweaked/peripherals/TransporterPeripheral.java
@@ -18,7 +18,7 @@ public class TransporterPeripheral extends InterfacePeripheral
 	
 	public TransporterPeripheral(AbstractInterfaceEntity interfaceEntity, AbstractTransporterEntity<?> transporter)
 	{
-		super(interfaceEntity);
+		super(interfaceEntity, transporter);
 		this.transporter = transporter;
 		
 		transporter.registerInterfaceMethods(new SGJourneyPeripheralWrapper<>(this, interfaceEntity.getInterfaceType()));


### PR DESCRIPTION
- Added targeted block entity into InterfacePeripheral to track for which block entity the peripheral was initialized
- InterfacePeripheralWrapper is now checking whether the original entity is the same that is being targeted by the interface
- If changed, the original Lazy peripheral initializer is invalidated, and a new one is created