### PR TITLE
[CI] Update publish workflows to v2.2.0, enable sequential publication to keep artifact order

### DIFF
--- a/.github/workflows/manual-trigger-draft-release.yml
+++ b/.github/workflows/manual-trigger-draft-release.yml
@@ -33,13 +33,13 @@ jobs:
     # Using a specific version prevents breaking your workflow when a breaking change is introduced
     # If a specific commit hash is used, improves security
     # The reference must be changed at TWO places                                       ↓ change this
-    # v2.1.0
-    uses: lukaskabc/Minecraft-Mod-Publish-Workflows/.github/workflows/draft-release.yml@14f5fd1e0ba5247143318b00f0029c6493624a14
+    # v2.2.0
+    uses: lukaskabc/Minecraft-Mod-Publish-Workflows/.github/workflows/draft-release.yml@1e32c97d6ea778d93b5f57d818306a364fd264aa
     with:
       # CHANGE THIS REFERENCE AS WELL
       # This value must match the reference used in the "uses:" parameter (the value after "@")
-      # v2.1.0
-      workflow_ref: "14f5fd1e0ba5247143318b00f0029c6493624a14"
+      # v2.2.0
+      workflow_ref: "1e32c97d6ea778d93b5f57d818306a364fd264aa"
 
       # Passthrough for workflow dispatch inputs, do not change
       version: ${{ inputs.version }}

--- a/.github/workflows/release-trigger-mod-publish.yml
+++ b/.github/workflows/release-trigger-mod-publish.yml
@@ -22,16 +22,18 @@ jobs:
     # Using a specific version prevents breaking your workflow when a breaking change is introduced
     # If a specific commit hash is used, improves security
     # The reference must be changed at TWO places                                     ↓ change this
-    # v2.1.0
-    uses: lukaskabc/Minecraft-Mod-Publish-Workflows/.github/workflows/mod-publish.yml@14f5fd1e0ba5247143318b00f0029c6493624a14
+    # v2.2.0
+    uses: lukaskabc/Minecraft-Mod-Publish-Workflows/.github/workflows/mod-publish.yml@1e32c97d6ea778d93b5f57d818306a364fd264aa
     with:
       # CHANGE THIS REFERENCE AS WELL
       # This value must match the reference used in the "uses:" parameter (the value after "@")
-      # v2.1.0
-      workflow_ref: "14f5fd1e0ba5247143318b00f0029c6493624a14"
+      # v2.2.0
+      workflow_ref: "1e32c97d6ea778d93b5f57d818306a364fd264aa"
 
       # The tag with associated release dynamically pulled from the GitHub event payload
       release_tag: ${{ github.event.release.tag_name }}
+
+      sequential_publication: true
 
     secrets:
       CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}


### PR DESCRIPTION
Publication of individual artifacts will now happen in sequence, keeping their order as defined in `publish.config.json`

`1.19.2` is being published as the first, and `1.21.1` as the last, keeping the `1.21.1` at the top of the version list