### PR TITLE
Worldhight fixes

### DIFF
--- a/src/main/resources/data/sgjourney/dimension/rima.json
+++ b/src/main/resources/data/sgjourney/dimension/rima.json
@@ -15,8 +15,8 @@
             "erosion": 0,
             "weirdness": 0,
             "depth": [
-              -2,
-              0.6
+              -1,
+              0.8671875
             ],
             "offset": 0
           }
@@ -30,8 +30,8 @@
             "erosion": 0,
             "weirdness": 0,
             "depth": [
-              0.6,
-              2
+              0.8671875,
+              1
             ],
             "offset": 0
           }

--- a/src/main/resources/data/sgjourney/dimension_type/rima.json
+++ b/src/main/resources/data/sgjourney/dimension_type/rima.json
@@ -9,10 +9,10 @@
 	"has_ceiling": false,
 	"coordinate_scale": 1,
 	"ambient_light": 0,
-	"logical_height": 384,
+	"logical_height": 256,
 	"infiniburn": "#minecraft:infiniburn_overworld",
-	"min_y": -64,
-	"height": 384,
+	"min_y": 0,
+	"height": 256,
 	"monster_spawn_light_level":
 	{
 		"type": "minecraft:uniform",

--- a/src/main/resources/data/sgjourney/dimension_type/tollan.json
+++ b/src/main/resources/data/sgjourney/dimension_type/tollan.json
@@ -9,10 +9,10 @@
 	"has_ceiling": false,
 	"coordinate_scale": 1,
 	"ambient_light": 0,
-	"logical_height": 384,
+	"logical_height": 256,
 	"infiniburn": "#minecraft:infiniburn_overworld",
-	"min_y": -64,
-	"height": 384,
+	"min_y": 0,
+	"height": 256,
 	"monster_spawn_light_level":
 	{
 		"type": "minecraft:uniform",

--- a/src/main/resources/data/sgjourney/worldgen/noise_settings/rima.json
+++ b/src/main/resources/data/sgjourney/worldgen/noise_settings/rima.json
@@ -38,8 +38,8 @@
     "erosion": "sgjourney:cracked_ridges",
     "depth": {
       "type": "minecraft:y_clamped_gradient",
-      "from_y": -64,
-      "to_y": 320,
+      "from_y": 0,
+      "to_y": 256,
       "from_value": 1.5,
       "to_value": -1.5
     },


### PR DESCRIPTION
Fixes #247 
Removes the extra 64 blocks from under the world in Rima and Tollan, under the assumption you intended those dimensions to be 256 blocks high.
Doesn't appear to have any side effects. Even works which chucks loaded before the fix was applied, without any seams.