### PR TITLE
Fix update 0.6.48 breaking all pickaxes.

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -5,7 +5,6 @@
 		"sgjourney:universe_stargate",
 		"sgjourney:universe_ring",
 		"sgjourney:universe_shielding",
-		"sgjourney:milky_dhd",
 		
 		"sgjourney:universe_stargate_chevron",
 		


### PR DESCRIPTION
Fixes #255 

Seems as part of 7167defc72e844dca613803ad6b031601e4d9db1, a rouge `"sgjourney:milky_dhd",`  entry was added.
https://github.com/Povstalec/StargateJourney/blob/7167defc72e844dca613803ad6b031601e4d9db1/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json#L8

As this block doesn't exist, it seems to kill the tag. Thus  pickaxes aren't able to mine any block better than an empty hand.
```
[14:05:01] [Worker-ResourceReload-13/ERROR] [minecraft/TagLoader]: Couldn't load tag minecraft:mineable/pickaxe as it is missing following references: 
	sgjourney:milky_dhd (from mod/sgjourney)
```

As there is already a `"sgjourney:milky_way_dhd",` in the file, I assume this was added on accident and removed it.