### PR TITLE
fix: Crystallizer now requires input fluid to craft

### DIFF
--- a/src/main/java/net/povstalec/sgjourney/common/recipe/CrystallizingRecipe.java
+++ b/src/main/java/net/povstalec/sgjourney/common/recipe/CrystallizingRecipe.java
@@ -94,7 +94,7 @@ public abstract class CrystallizingRecipe extends ProgressRecipe<CrystallizingRe
 		if(level.isClientSide())
 			return false;
 		
-		return itemStackMatches(craftingInput, 0) && itemStackMatches(craftingInput, 1) && itemStackMatches(craftingInput, 2);
+		return itemStackMatches(craftingInput, 0) && itemStackMatches(craftingInput, 1) && itemStackMatches(craftingInput, 2) && craftingInput.testFluid(0, inputFluid);
 	}
 	
 	@Override


### PR DESCRIPTION
CrystallizingRecipe.matches() only checked the three item slots and
never validated the recipe's input_fluid, so the Crystallizer and
Advanced Crystallizer could craft without any liquid even though JEI
shows liquid naquadah as required. Added the missing fluid check via
craftingInput.testFluid(0, inputFluid), aligning machine behavior
with the JEI recipe display.